### PR TITLE
chore(nginx): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM quay.io/cdis/ubuntu:18.04
 
 #
 # point at nginx apt package repo, and install nginx,


### PR DESCRIPTION
Unblocking release202101 by avoiding the following error in Quay:
```
Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. 
You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

### Improvements
- Adopt quay.io image to avoid `API error (500): toomanyrequests` produced by Dockerhub.