### PR TITLE
chore(ingress-config): All ingress config should be here now

### DIFF
--- a/ingress-config/README.md
+++ b/ingress-config/README.md
@@ -1,0 +1,3 @@
+# TL;DR
+
+Decomposed nginx reverse proxy configuration.  Use `gen3 kube-setup-revproxy` to update the revproxy config.

--- a/ingress-config/access-backend-service.conf
+++ b/ingress-config/access-backend-service.conf
@@ -1,0 +1,11 @@
+          location /access-backend/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "access-backend-service";
+              set $upstream http://access-backend-service$des_domain;
+              rewrite ^/access-backend/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/access-backend/;
+          }

--- a/ingress-config/ambassador-service.conf
+++ b/ingress-config/ambassador-service.conf
@@ -1,0 +1,48 @@
+          location /lw-workspace/proxy/ {
+              set $authz_resource "/workspace";
+              set $authz_method "access";
+              set $authz_service "jupyterhub";
+              # be careful - sub-request runs in same context as this request
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+              auth_request /gen3-authz;
+
+              if ($saved_set_cookie != "") {
+                  add_header Set-Cookie $saved_set_cookie always;
+              }
+              add_header Cache-Control "no-store";
+
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 403 = @errorworkspace;
+
+              set $proxy_service  "ambassador";
+              set $upstream http://ambassador-service.$namespace.svc.cluster.local;
+              rewrite ^/lw-workspace/proxy/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/lw-workspace/proxy/;
+              proxy_http_version 1.1;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              proxy_set_header X-URL-SCHEME https;
+              client_max_body_size 0;
+              # for fixing noVNC connection timeout issue
+              proxy_read_timeout 36000s;
+          }
+
+          #location /ambadm/ {
+          #    auth_request /authn-proxy;
+          #    auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+
+          #    proxy_set_header REMOTE_USER $remoteUser;
+          #    error_page 403 = @errorworkspace;
+          #    proxy_http_version 1.1;
+          #    set $proxy_service  "ambassador";
+          #    set $upstream http://ambassador-admin-service.$namespace.svc.cluster.local;
+          #    rewrite ^/ambadm/(.*) /ambassador/v0/diag/$1 break;
+          #    proxy_pass $upstream;
+          #    proxy_set_header Host $host;
+          #    proxy_redirect http://$host/ambassador/v0/diag/ https://$host/ambadm/;
+          #}

--- a/ingress-config/arborist-service.conf
+++ b/ingress-config/arborist-service.conf
@@ -1,0 +1,86 @@
+#
+# workspace AuthZ-proxy uses arborist to provide authorization to workpace services
+# that don't implement our authn or authz i.e. shiny, jupyter.
+#
+location = /gen3-authz {
+    internal;
+    error_page 400 =403 @errorworkspace;
+    error_page 500 =403 @errorworkspace;
+
+    # avoid setting $upstream in authz subrequests ...
+    set $upstream_authz http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    proxy_pass $upstream_authz/auth/proxy?resource=$authz_resource&method=$authz_method&service=$authz_service;
+
+    proxy_pass_request_body off;
+    proxy_set_header Authorization "$access_token";
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Forwarded-For "$realip";
+    proxy_set_header X-UserId "$userid";
+    proxy_set_header X-ReqId "$request_id";
+    proxy_set_header X-SessionId "$session_id";
+    proxy_set_header X-VisitorId "$visitor_id";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_intercept_errors on;
+
+    # nginx bug that it checks even if request_body off
+    client_max_body_size 0;
+}
+
+#
+# authorization endpoint
+# https://hostname/authz?resource=programs/blah&method=acb&service=xyz
+#
+location ~ /authz/? {
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
+    set $proxy_service  "arborist";
+    set $upstream http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    proxy_pass $upstream/auth/proxy?resource=$arg_resource&method=$arg_method&service=$arg_service;
+}
+
+location = /authz/resources {
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
+    set $proxy_service  "arborist";
+    set $upstream http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    proxy_pass $upstream/auth/resources;
+}
+
+location = /authz/mapping {
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
+
+    # Do not expose POST /auth/mapping
+    limit_except GET {
+        deny all;
+    }
+
+    set $proxy_service  "arborist";
+    set $upstream http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    # Do not pass the username arg here! Otherwise anyone can see anyone's access.
+    # Arborist will fall back to parsing the jwt for username.
+    proxy_pass $upstream/auth/mapping;
+}
+
+#
+# Little endpoint for testing that authz is being enforced
+#
+location = /gen3-authz-test {
+    set $authz_resource "/fail";
+    set $authz_method "user";
+    set $authz_service "bogus";
+
+    # be careful - sub-request runs in same context as this request
+    auth_request /gen3-authz;
+
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service.$namespace.svc.cluster.local;
+    proxy_pass $upstream/$authz_method;
+}

--- a/ingress-config/arranger-service.conf
+++ b/ingress-config/arranger-service.conf
@@ -1,0 +1,14 @@
+          location /api/v0/flat-search/ {
+              #
+              # Arranger UI does not set csrf headers ..
+              #
+              #if ($csrf_check !~ ^ok-\S.+$) {
+              #  return 403 "failed csrf check";
+              #}
+              set $proxy_service  "arranger";
+              # this goes into the logs ...
+              set $upstream http://arranger-service.$namespace.svc.cluster.local;
+              rewrite ^/api/v0/flat-search/(.*) /$1 break;
+              proxy_pass $upstream;
+              client_max_body_size 0;
+          }

--- a/ingress-config/audit-service.conf
+++ b/ingress-config/audit-service.conf
@@ -1,0 +1,16 @@
+location /audit/ {
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
+
+    # only allow GET requests. POSTing audit logs is only for internal use
+    limit_except GET {
+      deny all;
+    }
+
+    set $proxy_service  "audit-service";
+    set $upstream http://audit-service$des_domain;
+    rewrite ^/audit/(.*) /$1 break;
+    proxy_pass $upstream;
+    proxy_redirect http://$host/ https://$host/audit/;
+}

--- a/ingress-config/auspice-service.conf
+++ b/ingress-config/auspice-service.conf
@@ -1,0 +1,8 @@
+          location /auspice/ {
+              set $proxy_service  "auspice";
+              # upstream is written to logs
+              set $upstream http://auspice-service.$namespace.svc.cluster.local;
+              rewrite ^/auspice/(.*) /$1 break;
+              proxy_pass $upstream;
+              client_max_body_size 0;
+          }

--- a/ingress-config/cogwheel-service.conf
+++ b/ingress-config/cogwheel-service.conf
@@ -1,0 +1,14 @@
+location /cogwheel/ {
+
+    # Use https bc cogwheel only listens on 443
+    set $upstream https://cogwheel-service$des_domain;
+
+    # Do not rewrite URLs.
+    # Very briefly: The Shibboleth module packages up a redirect URL
+    # (pointing to the SAML ACS) and sends it encoded to the IdP.
+    # So Cogwheel needs to "know about" the /cogwheel/ fragment
+    # in order to generate the right redirect URL.
+    #rewrite ^/cogwheel/(.*) /$1 break;
+
+    proxy_pass $upstream;
+}

--- a/ingress-config/dashboard.conf
+++ b/ingress-config/dashboard.conf
@@ -1,0 +1,20 @@
+          location /dashboard/Secure/ {
+              error_page 403 @errorworkspace;
+              set $authz_resource "/dashboard";
+              set $authz_method "access";
+              set $authz_service "dashboard";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              set $proxy_service  "dashboard";
+              set $upstream http://dashboard.$namespace.svc.cluster.local:4000;
+              rewrite ^/dashboard/(.*) /$1 break;
+              proxy_pass $upstream;
+          }
+
+          location /dashboard/Public/ {
+              set $proxy_service  "dashboard";
+              set $upstream http://dashboard.$namespace.svc.cluster.local:4000;
+              rewrite ^/dashboard/(.*) /$1 break;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/devbot-service.conf
+++ b/ingress-config/devbot-service.conf
@@ -1,0 +1,12 @@
+          set $devbot_release_name "devbot";
+          location /devbot/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "${devbot_release_name}";
+              set $upstream http://${devbot_release_name}-service$des_domain;
+              rewrite ^/devbot/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/devbot/;
+          }

--- a/ingress-config/fence-service.conf
+++ b/ingress-config/fence-service.conf
@@ -1,0 +1,68 @@
+# AuthN-proxy uses fence to provide authentication to downstream services
+# that don't implement our auth i.e. shiny, jupyter.
+# Fence also sets the REMOTE_USER header to the username
+# of the logged in user for later use
+location /authn-proxy {
+    internal;
+    set $proxy_service  "${fence_release_name}";
+    set $upstream_auth http://${fence_release_name}-service${des_domain}/user/anyaccess;
+    proxy_pass $upstream_auth;
+    proxy_pass_request_body off;
+    proxy_set_header Authorization "$access_token";
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Forwarded-For "$realip";
+    proxy_set_header X-UserId "$userid";
+    proxy_set_header   X-ReqId "$request_id";
+    proxy_set_header   X-SessionId "$session_id";
+    proxy_set_header   X-VisitorId "$visitor_id";
+
+    # nginx bug that it checks even if request_body off
+    client_max_body_size 0;
+}
+
+location /user/ {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service$des_domain;
+    rewrite ^/user/(.*) /$1 break;
+    proxy_pass $upstream;
+}
+
+location /user/register {
+    # Like /user/ but without CSRF check. Registration form submission is
+    # incompatible with revproxy-level cookie-to-header CSRF check.
+    # Fence enforces its own CSRF protection here so this is OK.
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service$des_domain;
+    rewrite ^/user/(.*) /$1 break;
+    proxy_pass $upstream;
+}
+
+location /user/data/download {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "${presigned_url_fence_release_name}";
+    set $upstream http://${presigned_url_fence_release_name}-service$des_domain;
+    rewrite ^/user/(.*) /$1 break;
+    proxy_pass $upstream;
+}
+
+location /user/metrics {
+    deny all;
+}
+
+# OpenID Connect Discovery Endpoints
+location /.well-known/ {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service$des_domain;
+    proxy_pass $upstream;
+}

--- a/ingress-config/fenceshib-service.conf
+++ b/ingress-config/fenceshib-service.conf
@@ -1,0 +1,10 @@
+location / {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "${fenceshib_release_name}";
+    set $upstream http://${fenceshib_release_name}-service.$namespace.svc.cluster.local;
+    rewrite ^/(.*) /$1 break;
+    proxy_pass $upstream;
+}

--- a/ingress-config/google-sa-validation-service.conf
+++ b/ingress-config/google-sa-validation-service.conf
@@ -1,0 +1,7 @@
+          location /google-sa-validation-status/ {
+              set $proxy_service  "google-sa-validation";
+              # $upstream is written to logs ...
+              set $upstream http://google-sa-validation-service.$namespace.svc.cluster.local;
+              rewrite ^/google-sa-validation-status/(.*) /$1 break;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/grafana.conf
+++ b/ingress-config/grafana.conf
@@ -1,0 +1,17 @@
+         location /grafana/ {
+              error_page 403 @errorworkspace;
+              set $authz_resource "/prometheus";
+              set $authz_method "access";
+              set $authz_service "prometheus";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              proxy_set_header   Host $host;
+              proxy_set_header Authorization "Basic CREDS";
+
+              set $proxy_service  "grafana";
+              set $upstream http://grafana.grafana.svc.cluster.local;
+              rewrite ^/grafana/(.*) /$1 break;
+              proxy_pass $upstream;
+              #proxy_redirect http://$host/ https://$host/grafana/;
+          }

--- a/ingress-config/guppy-service.conf
+++ b/ingress-config/guppy-service.conf
@@ -1,0 +1,8 @@
+          location /guppy/ {
+              set $proxy_service  "guppy";
+              # upstream is written to logs
+              set $upstream http://guppy-service.$namespace.svc.cluster.local;
+              rewrite ^/guppy/(.*) /$1 break;
+              proxy_pass $upstream;
+              client_max_body_size 0;
+          }

--- a/ingress-config/hatchery-service.conf
+++ b/ingress-config/hatchery-service.conf
@@ -1,0 +1,34 @@
+
+          location /lw-workspace/ {
+              set $authz_resource "/workspace";
+              set $authz_method "access";
+              set $authz_service "jupyterhub";
+              # be careful - sub-request runs in same context as this request
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+              auth_request /gen3-authz;
+
+              if ($saved_set_cookie != "") {
+                  add_header Set-Cookie $saved_set_cookie always;
+              }
+
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 403 = @errorworkspace;
+
+              # Use this variable so nginx won't error out on start
+              # if not using the jupyterhub service
+              # this isn't dev namespace friendly, must be manually updated
+              set $proxy_service  "hatchery";
+              set $upstream http://hatchery-service.$namespace.svc.cluster.local;
+              rewrite ^/lw-workspace/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_set_header Authorization "$access_token";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              client_max_body_size 0;
+              # for fixing noVNC connection timeout issue
+              proxy_read_timeout 36000s;
+          }

--- a/ingress-config/indexd-service.conf
+++ b/ingress-config/indexd-service.conf
@@ -1,0 +1,57 @@
+
+          # GA4GH endpoint for DOS resolver and DRS server
+          location /ga4gh/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "${indexd_release_name}";
+              set $upstream http://${indexd_release_name}-service$des_domain;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/;
+          }
+
+          location /index/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "${indexd_release_name}";
+              set $upstream http://${indexd_release_name}-service$des_domain;
+              rewrite ^/index/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/index/;
+          }
+
+          location /index-admin/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+              set $authz_resource "/indexd_gateway";
+              set $authz_method "access";
+              set $authz_service "indexd_gateway";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              #
+              # For some reason nginx breaks the proxy body
+              # if we try to set Authorization from a perl_set variable
+              # that samples the environment ... ugh!
+              #
+              set $indexd_password "Basic ${indexd_b64}";
+
+              # For testing:
+              #add_header Set-Cookie "X-Frickjack=${indexd_password};Path=/;Max-Age=600";
+              set $proxy_service  "${indexd_release_name}";
+              set $upstream http://${indexd_release_name}-service$des_domain;
+              rewrite ^/index-admin/(.*) /$1 break;
+              proxy_set_header   Host $host;
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+              proxy_set_header   Authorization "$indexd_password";
+
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/index-admin/;
+          }

--- a/ingress-config/jupyterhub-service.conf
+++ b/ingress-config/jupyterhub-service.conf
@@ -1,0 +1,41 @@
+
+          # This works if the JupyterHub service is enabled
+          # The JupyterHub service is set to use REMOTE_USER auth
+          # So it trusts that the user is authenticated if the header
+          # is set and passed in
+          location /lw-workspace/ {
+              set $authz_resource "/workspace";
+              set $authz_method "access";
+              set $authz_service "jupyterhub";
+              # be careful - sub-request runs in same context as this request
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+              auth_request /gen3-authz;
+
+              if ($saved_set_cookie != "") {
+                  add_header Set-Cookie $saved_set_cookie always;
+              }
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 403 = @errorworkspace;
+
+              # Use this variable so nginx won't error out on start
+              # if not using the jupyterhub service
+              # this isn't dev namespace friendly, must be manually updated
+              set $proxy_service  "jupyterhub";
+              # $upstream is written to logs
+              set $upstream http://jupyterhub-service.$namespace.svc.cluster.local:8000;
+              proxy_pass $upstream;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              client_max_body_size 0;
+          }
+
+          # JupyterHub doesn't currently support chaining logout pages
+          # So route the jupyterhub logout to the fence logout path
+          # Fence is hence responsible for clearing all cookies
+          location = /lw-workspace/hub/logout {
+            return 301 $scheme://$host/user/logout?next=/;
+          }

--- a/ingress-config/manifestservice-service.conf
+++ b/ingress-config/manifestservice-service.conf
@@ -1,0 +1,13 @@
+
+                location /manifests/ {
+                  if ($csrf_check !~ ^ok-\S.+$) {
+                    return 403 "failed csrf check";
+                  }
+
+                  set $proxy_service  "${manifestservice_release_name}";
+                  set $upstream http://${manifestservice_release_name}-service.$namespace.svc.cluster.local;
+                  rewrite ^/manifests/(.*) /$1 break;
+                  proxy_pass $upstream;
+                  proxy_redirect http://$host/ https://$host/manifests/;
+                  client_max_body_size 0;
+                }

--- a/ingress-config/mariner-service.conf
+++ b/ingress-config/mariner-service.conf
@@ -1,0 +1,10 @@
+location /ga4gh/wes/v1/ {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "mariner";
+    set $upstream http://mariner-service.$namespace.svc.cluster.local;
+    rewrite ^/ga4gh/wes/v1/(.*) /$1 break;
+    proxy_pass $upstream;
+}

--- a/ingress-config/metadata-service.conf
+++ b/ingress-config/metadata-service.conf
@@ -1,0 +1,41 @@
+          location /mds/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "metadata-service";
+              set $upstream http://metadata-service$des_domain;
+              rewrite ^/mds/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/mds/;
+              client_max_body_size 0;
+          }
+
+          location /mds-admin/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+              set $authz_resource "/mds_gateway";
+              set $authz_method "access";
+              set $authz_service "mds_gateway";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              set $mds_password "Basic ${mds_b64}";
+
+              # For testing:
+              #add_header Set-Cookie "X-Frickjack=${mds_password};Path=/;Max-Age=600";
+              set $proxy_service  "metadata-service";
+              set $upstream http://metadata-service$des_domain;
+              rewrite ^/mds-admin/(.*) /$1 break;
+              proxy_set_header   Host $host;
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+              proxy_set_header   Authorization "$mds_password";
+
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/mds-admin/;
+              client_max_body_size 0;
+          }

--- a/ingress-config/peregrine-service.conf
+++ b/ingress-config/peregrine-service.conf
@@ -1,0 +1,70 @@
+          # Simplify external access to health checks
+          location /peregrine/_status {
+              set $proxy_service  "${peregrine_release_name}";
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local/_status;
+              proxy_pass $upstream;
+          }
+          location /peregrine/_version {
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local/_version;
+              proxy_pass $upstream;
+          }
+          location /api/search {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              gzip off;
+              proxy_next_upstream off;
+              proxy_set_header   Host $host;
+              proxy_set_header   Authorization "$access_token";
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-ReqId "$request_id";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+
+              proxy_connect_timeout 300;
+              proxy_send_timeout 300;
+              proxy_read_timeout 300;
+              send_timeout 300;
+
+              set $proxy_service  "${peregrine_release_name}";
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local;
+              rewrite ^/api/search/(.*) /$1 break;
+              proxy_pass $upstream;
+          }
+          location /api/v0/submission/graphql {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              gzip off;
+              proxy_next_upstream off;
+              proxy_set_header   Host $host;
+              proxy_set_header   Authorization "$access_token";
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-ReqId "$request_id";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+
+              proxy_connect_timeout 300;
+              proxy_send_timeout 300;
+              proxy_read_timeout 300;
+              send_timeout 300;
+
+              set $proxy_service  "${peregrine_release_name}";
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local/v0/submission/graphql;
+              proxy_pass $upstream;
+          }
+          location /api/v0/submission/getschema {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              proxy_next_upstream off;
+
+              set $proxy_service  "${peregrine_release_name}";
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local/v0/submission/getschema;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/pidgin-service.conf
+++ b/ingress-config/pidgin-service.conf
@@ -1,0 +1,16 @@
+          location /coremetadata/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              # redirect to coremetadata landing page if header does not specify otherwise
+              if ($http_accept !~ (application/json|x-bibtex|application/vnd\.schemaorg\.ld\+json)) {
+                rewrite ^/coremetadata/(.*) /files/$1 redirect;
+              }
+
+              set $proxy_service  "pidgin";
+              # $upstream is written to the logs
+              set $upstream http://pidgin-service.$namespace.svc.cluster.local;
+              rewrite ^/coremetadata/(.*) /$1 break;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/portal-service.conf
+++ b/ingress-config/portal-service.conf
@@ -1,0 +1,25 @@
+          location / {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              #
+              # Go into maintenance mode when both are true:
+              #  - MAINTENANCE_MODE environment variable is set
+              #  - devmode cookies is not set
+              #
+              set $maintenance_mode "$maintenance_mode_env";
+              if ($cookie_devmode) {
+                set $maintenance_mode "off";
+              }
+
+              set $proxy_service  "portal";
+              # $upstream is written to the logs
+              set $upstream http://portal-service.$namespace.svc.cluster.local;
+
+              if ($maintenance_mode = 'on') {
+                rewrite ^/(.*)$ /dashboard/Public/maintenance-page/index.html redirect;
+              }
+
+              proxy_pass $upstream;
+          }

--- a/ingress-config/portal-workspace-parent.conf
+++ b/ingress-config/portal-workspace-parent.conf
@@ -1,0 +1,10 @@
+        location /workspace-authorize/ {
+            js_content gen3_workspace_authorize_handler;
+        }
+
+        location / {
+            if ($csrf_check !~ ^ok-\S.+$) {
+              return 403 "failed csrf check";
+            }
+            rewrite ^/(.*)$ /dashboard/Public/index.html redirect;
+        }

--- a/ingress-config/prometheus-server.conf
+++ b/ingress-config/prometheus-server.conf
@@ -1,0 +1,14 @@
+         location /prometheus/ {
+              error_page 403 @errorworkspace;
+              set $authz_resource "/prometheus";
+              set $authz_method "access";
+              set $authz_service "prometheus";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              set $proxy_service  "prometheus";
+              set $upstream http://prometheus-server.prometheus.svc.cluster.local;
+              #rewrite ^/prometheus/(.*) /$1 break;
+              proxy_pass $upstream;
+              #proxy_redirect http://$host/ https://$host/prometheus/;
+          }

--- a/ingress-config/qa-dashboard-service.conf
+++ b/ingress-config/qa-dashboard-service.conf
@@ -1,0 +1,16 @@
+          location /qa-dashboard/ {
+            if ($csrf_check !~ ^ok-\S.+$) {
+              return 403 "failed csrf check";
+            }
+            set $upstream http://qa-dashboard-service$des_domain$request_uri;
+            proxy_pass $upstream;
+          }
+          location /views/ {
+            set $upstream http://qa-dashboard-service$des_domain/qa-dashboard$request_uri;
+            proxy_pass $upstream;
+            proxy_redirect http://$host/ https://$host/views/;
+          }
+          location /assets/ {
+            set $upstream http://qa-dashboard-service$des_domain/qa-dashboard$request_uri;
+            proxy_pass $upstream;
+          }

--- a/ingress-config/requestor-service.conf
+++ b/ingress-config/requestor-service.conf
@@ -1,0 +1,11 @@
+          location /requestor/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "requestor-service";
+              set $upstream http://requestor-service$des_domain;
+              rewrite ^/requestor/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/requestor/;
+          }

--- a/ingress-config/sheepdog-service.conf
+++ b/ingress-config/sheepdog-service.conf
@@ -1,0 +1,26 @@
+location /api/ {
+  if ($csrf_check !~ ^ok-\S.+$) {
+    return 403 "failed csrf check";
+  }
+
+  proxy_next_upstream off;
+  # Forward the host and set Subdir header so api
+  # knows the original request path for hmac signing
+  proxy_set_header   Host $host;
+  proxy_set_header   Subdir /api;
+  proxy_set_header   Authorization "$access_token";
+  proxy_set_header   X-Forwarded-For "$realip";
+  proxy_set_header   X-UserId "$userid";
+  proxy_set_header   X-SessionId "$session_id";
+  proxy_set_header   X-VisitorId "$visitor_id";
+
+  proxy_connect_timeout 300;
+  proxy_send_timeout 300;
+  proxy_read_timeout 300;
+  send_timeout 300;
+
+  set $proxy_service  "${sheepdog_release_name}";
+  set $upstream http://${sheepdog_release_name}-service.$namespace.svc.cluster.local;
+  rewrite ^/api/(.*) /$1 break;
+  proxy_pass $upstream;
+}

--- a/ingress-config/shiny-nb2-service.conf
+++ b/ingress-config/shiny-nb2-service.conf
@@ -1,0 +1,14 @@
+          # Exploration page until we finish redoing it
+          location ~ ^/(shiny|explore)/ {
+
+              # Use this variable so nginx won't error out on start
+              set $proxy_service  "shiny";
+              # $upstream is written to the logs
+              set $upstream http://shiny-nb2-service.$namespace.svc.cluster.local:3838;
+              proxy_pass $upstream;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+          }

--- a/ingress-config/shiny-service.conf
+++ b/ingress-config/shiny-service.conf
@@ -1,0 +1,18 @@
+          # Exploration page until we finish redoing it
+          location ~ ^/(shiny|explore)/ {
+              auth_request /authn-proxy;
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 401 = @errorworkspace;
+
+              # Use this variable so nginx won't error out on start
+              set $proxy_service  "shiny";
+              # $upstream is written to the logs
+              set $upstream http://shiny-service.$namespace.svc.cluster.local:3838;
+              proxy_pass $upstream;
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+          }

--- a/ingress-config/sower-service.conf
+++ b/ingress-config/sower-service.conf
@@ -1,0 +1,24 @@
+          location /job/ {
+              set $authz_resource "/sower";
+              set $authz_method "access";
+              set $authz_service "job";
+
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              auth_request /gen3-authz;
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 401 = @errorworkspace;
+
+              # Use this variable so nginx won't error out on start
+              set $proxy_service  "sower";
+              # $upstream is written to the logs
+              set $upstream http://sower-service.$namespace.svc.cluster.local;
+              rewrite ^/job/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_set_header Authorization "$access_token";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              client_max_body_size 0;
+          }

--- a/ingress-config/status-api-service.conf
+++ b/ingress-config/status-api-service.conf
@@ -1,0 +1,13 @@
+
+          set $status_api_release_name "status-api";
+          location /status/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              set $proxy_service  "${status_api_release_name}";
+              set $upstream http://${status_api_release_name}-service$des_domain;
+              rewrite ^/status/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/status/;
+          }

--- a/ingress-config/thor-service.conf
+++ b/ingress-config/thor-service.conf
@@ -1,0 +1,18 @@
+          location /thor/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              error_page 403 @errorworkspace;
+              set $authz_resource "/thor";
+              set $authz_method "access";
+              set $authz_service "thor";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              set $proxy_service  "thor-service";
+              set $upstream http://thor-service$des_domain;
+              rewrite ^/thor/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_redirect http://$host/ https://$host/thor/;
+          }

--- a/ingress-config/tty.conf
+++ b/ingress-config/tty.conf
@@ -1,0 +1,14 @@
+         location /tty/ {
+              error_page 403 @errorworkspace;
+              set $authz_resource "/ttyadmin";
+              set $authz_method "access";
+              set $authz_service "ttyadmin";
+              # be careful - sub-request runs in same context as this request
+              auth_request /gen3-authz;
+
+              set $proxy_service  "tty";
+              set $upstream http://tty$des_domain;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection $connection_upgrade;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/workspace-token-service.conf
+++ b/ingress-config/workspace-token-service.conf
@@ -1,0 +1,21 @@
+          location /wts/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              gzip off;
+              proxy_next_upstream off;
+              proxy_set_header   Host $host;
+              proxy_set_header   Authorization "$access_token";
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-ReqId "$request_id";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+
+              set $proxy_service  "wts";
+              # $upstream is written to the logs
+              set $upstream http://workspace-token-service.$namespace.svc.cluster.local;
+              rewrite ^/wts/(.*) /$1 break;
+              proxy_pass $upstream;
+          }

--- a/ingress-config/ws-storage.conf
+++ b/ingress-config/ws-storage.conf
@@ -1,0 +1,31 @@
+          location /ws-storage/ {
+              set $authz_resource "/workspace";
+              set $authz_method "access";
+              set $authz_service "jupyterhub";
+              # be careful - sub-request runs in same context as this request
+              auth_request_set $remoteUser $upstream_http_REMOTE_USER;
+              auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+              auth_request /gen3-authz;
+
+              if ($saved_set_cookie != "") {
+                  add_header Set-Cookie $saved_set_cookie always;
+              }
+
+              proxy_set_header REMOTE_USER $remoteUser;
+              error_page 403 = @errorworkspace;
+
+              # Use this variable so nginx won't error out on start
+              # if not using the jupyterhub service
+              # this isn't dev namespace friendly, must be manually updated
+              set $proxy_service  "ws-storage";
+              set $upstream http://ws-storage.$namespace.svc.cluster.local;
+              #rewrite ^/lw-workspace/(.*) /$1 break;
+              proxy_pass $upstream;
+              proxy_set_header Authorization "$access_token";
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              #proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              #proxy_set_header Upgrade $http_upgrade;
+              #proxy_set_header Connection $connection_upgrade;
+              #client_max_body_size 0;
+          }


### PR DESCRIPTION
Our nginx config is currently in cloud-automation and our microservices code changes sit in their respective repos.
As we don't have monorepo, the code changes that reflect in new behaviors for our RESTful API endpoints are not in sync / not backwards compatible with our Nginx / Reverse Proxy configuration changes that perform the URL Rewrites that will control the ingress of our Gen3 Ecosystem and redirect the inbound requests to the correct services.

With this approach, we will be able to have specific microservices versions coupled with specific docker-nginx (revproxy) versions and avoid awkward conditions to apply different revproxy configs for specific microservices versions.